### PR TITLE
Allow for dynamic metric name

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,12 +18,13 @@ const (
 )
 
 var (
-	identifierRE   = `[a-zA-Z_][a-zA-Z0-9_]+`
-	statsdMetricRE = `[a-zA-Z_](-?[a-zA-Z0-9_])+`
+	identifierRE      = `[a-zA-Z_][a-zA-Z0-9_]+`
+	statsdMetricRE    = `[a-zA-Z_](-?[a-zA-Z0-9_])+`
+	templateReplaceRE = `(\$\{?\d+\}?)`
 
 	metricLineRE = regexp.MustCompile(`^(\*\.|` + statsdMetricRE + `\.)+(\*|` + statsdMetricRE + `)$`)
+	metricNameRE = regexp.MustCompile(`^([a-zA-Z_]|` + templateReplaceRE + `)([a-zA-Z0-9_]|` + templateReplaceRE + `)*$`)
 	labelLineRE  = regexp.MustCompile(`^(` + identifierRE + `)\s*=\s*"(.*)"$`)
-	metricNameRE = regexp.MustCompile(`^` + identifierRE + `$`)
 )
 
 type metricMapper struct {


### PR DESCRIPTION
This allows for dynamic metric names as provided by https://github.com/prometheus/statsd_exporter/pull/117 based on the changes to the regexes [here](https://github.com/prometheus/statsd_exporter/pull/117/files#diff-6f04d273ed372d12e41ca448028cf7d3R28).